### PR TITLE
Support TypeScript 6 peer range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10528,7 +10528,7 @@
             "version": "0.1.0",
             "license": "ISC",
             "peerDependencies": {
-                "typescript": "^5.x"
+                "typescript": "^5.x || ^6.x"
             }
         },
         "packages/react": {
@@ -10537,7 +10537,7 @@
             "license": "ISC",
             "peerDependencies": {
                 "@types/react": "^18.x",
-                "typescript": "^5.x"
+                "typescript": "^5.x || ^6.x"
             }
         },
         "packages/string": {
@@ -10546,7 +10546,7 @@
             "license": "ISC",
             "peerDependencies": {
                 "@swisstype/essential": "^0.x",
-                "typescript": "^5.x"
+                "typescript": "^5.x || ^6.x"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10525,7 +10525,7 @@
         },
         "packages/essential": {
             "name": "@swisstype/essential",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "license": "ISC",
             "peerDependencies": {
                 "typescript": "^5.x || ^6.x"
@@ -10533,7 +10533,7 @@
         },
         "packages/react": {
             "name": "@swisstype/react",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "license": "ISC",
             "peerDependencies": {
                 "@types/react": "^18.x",
@@ -10542,7 +10542,7 @@
         },
         "packages/string": {
             "name": "@swisstype/string",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "ISC",
             "peerDependencies": {
                 "@swisstype/essential": "^0.x",

--- a/packages/essential/package.json
+++ b/packages/essential/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@swisstype/essential",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Your faithful Swiss Knife of essential types.",
     "private": false,
     "types": "index.d.ts",

--- a/packages/essential/package.json
+++ b/packages/essential/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@swisstype/essential",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Your faithful Swiss Knife of essential types.",
     "private": false,
     "types": "index.d.ts",

--- a/packages/essential/package.json
+++ b/packages/essential/package.json
@@ -11,7 +11,7 @@
     "author": "Peersyst",
     "license": "ISC",
     "peerDependencies": {
-        "typescript": "^5.x"
+        "typescript": "^5.x || ^6.x"
     },
     "sideEffects": false,
     "publishConfig": {

--- a/packages/essential/package.json
+++ b/packages/essential/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@swisstype/essential",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Your faithful Swiss Knife of essential types.",
     "private": false,
     "types": "index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,7 @@
     "license": "ISC",
     "peerDependencies": {
         "@types/react": "^18.x",
-        "typescript": "^5.x"
+        "typescript": "^5.x || ^6.x"
     },
     "sideEffects": false,
     "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@swisstype/react",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Your faithful Swiss Knife of react types.",
     "private": false,
     "types": "index.d.ts",

--- a/packages/string/package.json
+++ b/packages/string/package.json
@@ -12,7 +12,7 @@
     "license": "ISC",
     "peerDependencies": {
         "@swisstype/essential": "^0.x",
-        "typescript": "^5.x"
+        "typescript": "^5.x || ^6.x"
     },
     "sideEffects": false,
     "publishConfig": {

--- a/packages/string/package.json
+++ b/packages/string/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@swisstype/string",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Your faithful Swiss Knife of string types.",
     "private": false,
     "types": "index.d.ts",


### PR DESCRIPTION
## Summary
- widen TypeScript peer dependency ranges for @swisstype/essential, @swisstype/string, and @swisstype/react to support TypeScript 6
- update package-lock workspace metadata for the same peer ranges

## Verification
- npm run build

Note: npm run lint currently fails on existing Prettier issues in packages/string/index.d.ts, unrelated to this change.